### PR TITLE
Add "v"/"V" to defaultAlphabet

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ jwt-cracker <token> [<alphabet>] [<maxLength>]
 Where:
 
 * **token**: the full HS256 JWT token string to crack
-* **alphabet**: the alphabet to use for the brute force (default: "abcdefghijklmnopqrstuwxyzABCDEFGHIJKLMNOPQRSTUWXYZ0123456789")
+* **alphabet**: the alphabet to use for the brute force (default: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 * **maxLength**: the max length of the string generated during the brute force (default: 12)
 
 

--- a/index.js
+++ b/index.js
@@ -6,7 +6,7 @@ const crypto = require('crypto');
 const variationsStream = require('variations-stream');
 const pkg = require('./package');
 
-const defaultAlphabet = 'abcdefghijklmnopqrstuwxyzABCDEFGHIJKLMNOPQRSTUWXYZ0123456789';
+const defaultAlphabet = 'abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789';
 const defaultMaxLength = 12;
 const token = process.argv[2];
 const alphabet = process.argv[3] || defaultAlphabet;


### PR DESCRIPTION
Not sure if you have a specific problem with the letter "v" or if this is your way to make your "VvV"- HS256 secret more secure than any other secret. 
.. or you simply forgot that poor letter. 