### PR TITLE
JSON Web Tokens should be base64Url encoded

### DIFF
--- a/index.js
+++ b/index.js
@@ -33,6 +33,8 @@ const generateSignature = function(content, secret) {
       .update(content)
       .digest('base64')
       .replace('=', '')
+      .replace('+', '-')
+      .replace('/', '_')
   );
 };
 


### PR DESCRIPTION
Hi,

I've been playing with JWT Cracker because a while back I built my own JWT generator, see...

https://github.com/RobDWaller/ReallySimpleJWT

I just wanted to test and look at secret security. I noticed however that the cracker wasn't able to work out some secrets even when I made it really easy and obvious.

```shell
# The Secret is carpark

jwt-cracker "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxLCJpc3MiOiIxOTIuMTY4LjIxLjU2IiwiZXhwIjoiMjAxOC0wMS0yMSAyMjozNTo1MyIsInN1YiI6IiIsImF1ZCI6IiJ9.tDf_SPSR0983GiWjkK6purvVO-BVoxkSPtLB53Q8Jw0" "ackpr" 7
```

Anyway I looked at the code and I noticed the signatures you're generating aren't Base64Url encoded as they should be for JWTs.

https://tools.ietf.org/html/rfc7519#section-3

>A JWT is represented as a sequence of URL-safe parts separated by
   period ('.') characters.  Each part contains a base64url-encoded
   value.  The number of parts in the JWT is dependent upon the
   representation of the resulting JWS using the JWS Compact
   Serialization or JWE using the JWE Compact Serialization.

Base64Url encoding is slightly different from Base64 encoding as outlined here...

https://brockallen.com/2014/10/17/base64url-encoding/

But basically you just replace `+` with `-` and `/` with `_`.

I hope this little fix helps and please do let me know if I've got anything wrong or missed anything. I am very happy to discuss this further if required.

And thank you for you work on this tool it is very useful.

Cheers, Rob 