### PR TITLE
Change replace method in generateSignature

### DIFF
--- a/index.js
+++ b/index.js
@@ -32,9 +32,9 @@ const generateSignature = function(content, secret) {
     crypto.createHmac('sha256', secret)
       .update(content)
       .digest('base64')
-      .replace('=', '')
-      .replace('+', '-')
-      .replace('/', '_')
+      .replace(/=/g, '')
+      .replace(/\+/g, '-')
+      .replace(/\//g, '_')
   );
 };
 


### PR DESCRIPTION
`replace ` method doesn't make a replacement when the parameter is a string. It converts it to a Regex without the `g` flag.
The consequence is that it will just replace the first occurrence found in the string. If signatures have mutliple `=`, `+` or `\` after convertion, just the first occurrence will be replaced and the signatures comparaison will fail.

To make a real string replacement, we need to do `string.split('=').join('');` or to pass directly a Regex with `g` flag.

This PR will fix #9 