### PR TITLE
Force skip validation option

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ npm install --global jwt-cracker
 From command line:
 
 ```bash
-jwt-cracker -t <token> [-a <alphabet>] [--max <maxLength>]
+jwt-cracker -t <token> [-a <alphabet>] [--max <maxLength>] [-f]
 ```
 
 Where:
@@ -34,7 +34,7 @@ Where:
 * **token**: the full HS256 JWT token string to crack
 * **alphabet**: the alphabet to use for the brute force (default: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789")
 * **maxLength**: the max length of the string generated during the brute force (default: 12)
-
+* **force**: force script to execute when the token isn't valid
 
 ## Requirements
 

--- a/__tests__/jwtValidator.test.js
+++ b/__tests__/jwtValidator.test.js
@@ -9,6 +9,7 @@ describe('JWTValidator', () => {
   const invalidHeaderToken = 'eyJhJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpqd3QtY3JhY2tlciJ9.c5ZqtVGS-Jc6WUJsaRBVzfpUOcMFLu0lo0fd2FwDnJE'
   const nonJwtTypToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6Ik5vdC1Kd3QifQ.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Ikpqd3QtY3JhY2tlciJ9.8SmsCZptHRoDeGclg5Tl_N5-tSJF24BBPYa_YKp8b4g'
   const validButUnsupportedHS512Token = 'eyJhbGciOiJIUzUxMiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6Imp3dC1jcmFja2VyIn0.CcyaiMxfTVbG0SNPW9btRr5mJ3DCt0LOjVFtNJZW6ogjJxbeT6tAixi1uut2M8rlbTBYOqAxD56eIL7AXXaatw'
+  const emptyToken = ''
 
   describe('validateToken', () => {
     test('should return true for a valid HS256 JWT token', () => {
@@ -45,6 +46,11 @@ describe('JWTValidator', () => {
 
     test('should return false for a token with empty parts', () => {
       const result = JWTValidator.validateGeneralJwtFormat(invalidFormatEmptyPartsToken)
+      expect(result).toBe(false)
+    })
+
+    test('should return false if no token is provided', () => {
+      const result = JWTValidator.validateGeneralJwtFormat(emptyToken)
       expect(result).toBe(false)
     })
   })

--- a/argsParser.js
+++ b/argsParser.js
@@ -6,7 +6,7 @@ export default class ArgsParser {
   constructor () {
     this.args = yargs(hideBin(process.argv))
       .usage(
-        'Usage: jwt-cracker -t <token> [-a <alphabet>] [--max <maxLength>]'
+        'Usage: jwt-cracker -t <token> [-a <alphabet>] [--max <maxLength>] [-f]'
       )
       .option('t', {
         alias: 'token',
@@ -24,6 +24,11 @@ export default class ArgsParser {
         describe: 'Maximum length of the secret',
         default: Constants.DEFAULT_MAX_SECRET_LENGTH
       })
+      .option('f', {
+        alias: 'force',
+        type: 'boolean',
+        describe: 'Skip token validation'
+      })
       .help()
       .alias('h', 'help').argv
   }
@@ -38,5 +43,9 @@ export default class ArgsParser {
 
   get maxLength () {
     return this.args.max
+  }
+
+  get force () {
+    return this.args.force
   }
 }

--- a/index.js
+++ b/index.js
@@ -16,10 +16,11 @@ const args = new ArgsParser()
 const token = args.token
 const alphabet = args.alphabet
 const maxLength = args.maxLength
+const force = args.force || false
 
 const validToken = JWTValidator.validateToken(token)
 
-if (!validToken) {
+if (!validToken && (!force || !token.length)) {
   process.exit(Constants.EXIT_CODE_FAILURE)
 }
 

--- a/jwtValidator.js
+++ b/jwtValidator.js
@@ -7,6 +7,11 @@ export default class JWTValidator {
   }
 
   static validateGeneralJwtFormat (token) {
+    if (token.length === 0) {
+      console.log('Missing token')
+      return false
+    }
+
     const parts = token.split('.')
 
     if (parts.length !== 3 || !parts.every(part => part.length > 0)) {
@@ -34,7 +39,7 @@ export default class JWTValidator {
     }
 
     if (decodedHeader.typ !== 'JWT') {
-      console.log(`Unsupported Typ: ${decodedHeader.alg}`)
+      console.log(`Unsupported Typ: ${decodedHeader.typ}`)
       return false
     }
 


### PR DESCRIPTION
- Added `-f` / `--force` option

In some case the jwt token may not have `typ` specified, so the validator prevent the script from starting


- Added `Missing token` error message when token is not provided
- Changed the `Unsupported typ` error message to display the acual token `typ` instead of `alg`